### PR TITLE
soc: arm: st_bluenrg: Fix board naming convention in the soc file

### DIFF
--- a/drivers/clock_control/clock_bluenrglp.c
+++ b/drivers/clock_control/clock_bluenrglp.c
@@ -458,7 +458,7 @@ uint8_t SystemClockConfig(uint8_t SysClk)
     return ret_val;
   }
   
-#ifdef CONFIG_DEVICE_BLUENRG_LP
+#ifdef CONFIG_SOC_BLUENRG_LP
   /* BlueNRG_LP cut 1.0 not support DIRECT HSE configuration */
   if ((SysClk == SYSCLK_DIRECT_HSE) && (((LL_SYSCFG_GetDeviceVersion()<<4)|LL_SYSCFG_GetDeviceRevision()) == LL_BLUENRG_LP_CUT_10)) {
     return SYSTEM_CONFIG_DIRECT_HSE_NOT_SUPPORTED;


### PR DESCRIPTION
Match the board naming convention.