### PR TITLE
boards: st: Add STEVAL-IDB012V1 board

### DIFF
--- a/boards/st/steval_idb011v2/Kconfig.steval_idb011v2
+++ b/boards/st/steval_idb011v2/Kconfig.steval_idb011v2
@@ -1,4 +1,4 @@
-# BLUENRG-232 board configuration
+# BLUENRG-355 board configuration
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/boards/st/steval_idb012v1/Kconfig.defconfig
+++ b/boards/st/steval_idb012v1/Kconfig.defconfig
@@ -1,0 +1,26 @@
+# STEVAL-IDB012V1 board configuration
+
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_STEVAL_IDB012V1
+
+config BOARD
+	default "steval_idb012v1"
+
+if BT
+
+choice BT_HCI_BUS_TYPE
+	default BT_STM32WB0
+endchoice
+
+choice BT_RECV_CONTEXT
+	default BT_RECV_WORKQ_BT
+endchoice
+
+config BT_HCI_ACL_FLOW_CONTROL
+	default n
+
+endif # BT
+
+endif # BOARD_STEVAL_IDB012V1

--- a/boards/st/steval_idb012v1/Kconfig.steval_idb012v1
+++ b/boards/st/steval_idb012v1/Kconfig.steval_idb012v1
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_STEVAL_IDB012V1
+	bool "BLUENRG-LPS Evaluation Board"
+	depends on SOC_BLUENRG_LPS

--- a/boards/st/steval_idb012v1/board.cmake
+++ b/boards/st/steval_idb012v1/board.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/st/steval_idb012v1/board.yml
+++ b/boards/st/steval_idb012v1/board.yml
@@ -1,0 +1,5 @@
+board:
+  name: steval_idb012v1
+  vendor: st
+  socs:
+    - name: bluenrg_lps

--- a/boards/st/steval_idb012v1/steval_idb012v1.dts
+++ b/boards/st/steval_idb012v1/steval_idb012v1.dts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/bluenrg/bluenrg_lps.dtsi>
+#include <st/bluenrg_3/bluenrg-332.dtsi>
+
+/ {
+	model = "STMicroelectronics BLUENRG_LPS-STEVAL_IDB012V1 board";
+	compatible = "st,bluenrg_lp-steval_idb012v1";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
+	};
+	leds {
+		compatible = "gpio-leds";
+		green_led_2: led_3 {
+			gpios = <&gpiob 4 GPIO_ACTIVE_LOW>;
+			label = "User LD1";
+		};
+		red_led_2: led_4 {
+			gpios = <&gpiob 2 GPIO_ACTIVE_LOW>;
+			label = "User LD2";
+		};
+		rgb_led_1: led_5 {
+			gpios = <&gpiob 1 GPIO_ACTIVE_LOW>;
+			label = "User LD3";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button1: button1 {
+			label = "User Button 1";
+			gpios = <&gpioa 10 GPIO_ACTIVE_HIGH>;
+		};
+		user_button2: button2 {
+			label = "User Button 2";
+			gpios = <&gpiob 5 GPIO_ACTIVE_HIGH>;
+		};
+	};
+	aliases {
+		led0 = &green_led_2;
+		led1 = &red_led_2;
+		led2 = &rgb_led_1;
+		sw0 = &user_button1;
+		sw1 = &user_button2;
+	};
+
+};
+
+&clk_hse {
+	hse-bypass;
+	clock-frequency = <DT_FREQ_M(8)>; /* to be reviewed, possibly ignored by code */
+	status = "okay";
+};
+
+&pll {
+	clocks = <&clk_hse>;
+	mul = <8>;
+	div = <2>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(32)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+};
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pa1 &usart1_rx_pb0>;
+	pinctrl-names="default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&gpiob {
+	status = "okay";
+};
+
+&gpioa {
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4KB of storage at the end of 192KB flash */
+		storage_partition: partition@2f000 {
+			label = "storage";
+			reg = <0x0002f000 DT_SIZE_K(4)>;
+
+		};
+	};
+};
+
+&rng {
+	status = "okay";
+};
+
+/*
+ *
+ * &adc1 {
+ *	 status = "okay";
+ * };
+ *
+ * &spi1 {
+ *	 status = "okay";
+ * };
+ */

--- a/boards/st/steval_idb012v1/steval_idb012v1.yaml
+++ b/boards/st/steval_idb012v1/steval_idb012v1.yaml
@@ -1,0 +1,12 @@
+identifier: bluenrg_lps
+name: BLUENRG_LPS
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - counter
+ram: 24
+flash: 192

--- a/boards/st/steval_idb012v1/steval_idb012v1_defconfig
+++ b/boards/st/steval_idb012v1/steval_idb012v1_defconfig
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Zephyr Kernel Configuration
+CONFIG_SOC_SERIES_BLUENRG_3=y
+
+# Platform Configuration
+CONFIG_SOC_BLUENRG_LPS=y
+
+# TBD_st to be checked for relocation
+CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC=64000000
+
+# # Enable MPU
+# CONFIG_ARM_MPU=y
+
+# Serial Drivers
+CONFIG_SERIAL=y
+CONFIG_UART_INTERRUPT_DRIVEN=n
+# enable console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# GPIO Controller
+CONFIG_GPIO=y
+
+# Enable Clocks
+CONFIG_CLOCK_CONTROL=y
+CONFIG_CLOCK_CONTROL_BLUENRG_3=y
+
+# enable pin controller
+CONFIG_PINCTRL=y

--- a/boards/st/steval_idb012v1/support/openocd.cfg
+++ b/boards/st/steval_idb012v1/support/openocd.cfg
@@ -1,0 +1,7 @@
+source [find interface/cmsis-dap.cfg]
+
+transport select swd
+
+set CHIPNAME bluenrg_lps
+
+source [find target/bluenrg-x.cfg]

--- a/drivers/clock_control/clock_bluenrglp.c
+++ b/drivers/clock_control/clock_bluenrglp.c
@@ -458,12 +458,12 @@ uint8_t SystemClockConfig(uint8_t SysClk)
     return ret_val;
   }
   
-#ifdef CONFIG_SOC_BLUENRG_LP
+#if defined(CONFIG_SOC_BLUENRG_LP) || defined(CONFIG_SOC_BLUENRG_LPS)
   /* BlueNRG_LP cut 1.0 not support DIRECT HSE configuration */
   if ((SysClk == SYSCLK_DIRECT_HSE) && (((LL_SYSCFG_GetDeviceVersion()<<4)|LL_SYSCFG_GetDeviceRevision()) == LL_BLUENRG_LP_CUT_10)) {
     return SYSTEM_CONFIG_DIRECT_HSE_NOT_SUPPORTED;
   }
-#endif
+#endif /* defined(CONFIG_SOC_BLUENRG_LP) || defined(CONFIG_SOC_BLUENRG_LPS) */
   
   if (SysClk != SYSCLK_DIRECT_HSE) {
     /* System PLL Clock configuration */

--- a/drivers/gpio/CMakeLists.txt
+++ b/drivers/gpio/CMakeLists.txt
@@ -92,7 +92,7 @@ zephyr_library_sources_ifdef(CONFIG_GPIO_RENESAS_RA gpio_renesas_ra.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_ENE_KB1200 gpio_ene_kb1200.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_RZT2M    gpio_rzt2m.c)
 zephyr_library_sources_ifdef(CONFIG_GPIO_AMBIQ      gpio_ambiq.c)
-zephyr_library_sources_ifdef(CONFIG_GPIO_BLUENRG_3  gpio_bluenrg.c)
+zephyr_library_sources_ifdef(CONFIG_GPIO_BLUENRG  gpio_bluenrg.c)
 
 if (CONFIG_GPIO_EMUL_SDL)
   zephyr_library_sources(gpio_emul_sdl.c)

--- a/drivers/gpio/Kconfig.bluenrg
+++ b/drivers/gpio/Kconfig.bluenrg
@@ -3,7 +3,7 @@
 # Copyright (c) 2016 Open-RnD Sp. z o.o.
 # SPDX-License-Identifier: Apache-2.0
 
-config GPIO_BLUENRG_3
+config GPIO_BLUENRG
 	bool "GPIO Driver for BlueNRG-LPx Series of MCUs"
 	default y
 	depends on DT_HAS_ST_STM32_GPIO_ENABLED && SOC_SERIES_BLUENRG_3

--- a/dts/arm/st/bluenrg/bluenrg_lps.dtsi
+++ b/dts/arm/st/bluenrg/bluenrg_lps.dtsi
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024 STMicroelectronics
+ * Copyright (c) 2019 Linaro Limited
+ * Copyright (c) 2019 Centaur Analytics, Inc
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* This file is extracted from BlueNRG2 Zephyr integration Github made by a customer
+ * It needs to be updated for BlueNRG-LPS specifications
+ */
+
+#include <mem.h>
+#include <freq.h>
+#include <arm/armv6-m.dtsi>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/clock/bluenrg_lp_clock.h>
+#include <zephyr/dt-bindings/reset/bluenrg_lp_reset.h>
+
+/ {
+	chosen {
+		zephyr,entropy = &rng;
+		zephyr,flash-controller = &flash;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			device_type = "cpu";
+			compatible = "arm,cortex-m0+";
+			reg = <0>;
+		};
+	};
+
+	sram0: memory@20000000 {
+		device_type = "mmio-sram";
+		reg = <0x20000000 DT_SIZE_K(24)>;
+	};
+
+	clocks {
+		clk_hsi: clk-hsi {
+			#clock-cells = <0>;
+			compatible = "fixed-factor-clock";
+			clock-div = <4>;
+			status = "disabled";
+		};
+
+		clk_hse: clk-hse {
+			#clock-cells = <0>;
+			compatible = "st,stm32-hse-clock";
+			status = "disabled";
+		};
+
+		clk_lse: clk-lse {
+			#clock-cells = <0>;
+			compatible = "st,stm32-lse-clock";
+			clock-frequency = <32768>;
+			driving-capability = <0>;
+			status = "disabled";
+		};
+
+		clk_lsi: clk-lsi {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <33000>;
+			status = "disabled";
+		};
+
+		pll: pll {
+			#clock-cells = <0>;
+			compatible = "st,stm32l0-pll-clock";
+			status = "disabled";
+		};
+	};
+
+	soc {
+		flash: flash-controller@40001000 {
+			compatible = "st,stm32-flash-controller";
+			reg = <0x40001000 DT_SIZE_K(4)>;
+			interrupts = <1 0>;
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			flash0: flash@10040000 {
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
+				write-block-size = <16>;
+				erase-block-size = <2048>;
+				/* maximum erase time(ms) for a 2K sector */
+				max-erase-time = <40>;
+				reg = <0x10040000 DT_SIZE_K(192)>;
+			};
+		};
+
+		rcc: rcc@48400000 {
+			compatible = "st,stm32-rcc";
+			#clock-cells = <2>;
+			reg = <0x48400000 0x9C>;
+
+			rctl: reset-controller {
+				compatible = "st,stm32-rcc-rctl";
+				#reset-cells = <1>;
+			};
+		};
+
+		pinctrl: pin-controller@48000000 {
+			compatible = "st,stm32-pinctrl";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x48000000 DT_SIZE_K(2)>;
+
+			gpioa: gpio@48000000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x48000000 DT_SIZE_K(1)>;
+				/* AHB0 macro cells clock enable register (RCC_AHBENR) */
+				clocks = <&rcc BLUENRG_CLOCK_BUS_AHB0 0x00000004>;
+			};
+
+			gpiob: gpio@48100000 {
+				compatible = "st,stm32-gpio";
+				gpio-controller;
+				#gpio-cells = <2>;
+				reg = <0x48100000 DT_SIZE_K(1)>;
+				/* AHB0 macro cells clock enable register (RCC_AHBENR) */
+				clocks = <&rcc BLUENRG_CLOCK_BUS_AHB0 0x00000008>;
+			};
+		};
+
+		// Fake EXIT actually implemented with SYSCFG
+		exti: interrupt-controller@0 {
+			compatible = "st,stm32-exti";
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			#address-cells = <1>;
+			reg = <0x0 0x400>;
+			num-lines = <32>;
+			interrupts = <15 0>, <16 0>;
+			interrupt-names = "line0-15", "line16-31";
+			line-ranges = <0 16>, <1 16>;
+		};
+
+		usart1: serial@41004000 {
+			compatible = "st,stm32-usart", "st,stm32-uart";
+			reg = <0x41004000 DT_SIZE_K(1)>;
+			clocks = <&rcc BLUENRG_CLOCK_BUS_APB1 0x00000400>;
+			resets = <&rctl BLUENRG_RESET(APB1, 10U)>; // p73/515 RM0479
+			interrupts = <8 0>;
+			status = "disabled";
+		};
+
+		rng: rng@48600000 {
+			compatible = "st,stm32-rng";
+			reg = <0x48600000 DT_SIZE_K(1)>;
+			clocks = <&rcc BLUENRG_CLOCK_BUS_AHB0 0x00040000>;
+			status = "disabled";
+		};
+	};
+};
+
+&nvic {
+	arm,num-irq-priority-bits = <2>;
+};

--- a/soc/st/st_bluenrg/bluenrg_3/Kconfig.defconfig.bluenrg_lps
+++ b/soc/st/st_bluenrg/bluenrg_3/Kconfig.defconfig.bluenrg_lps
@@ -1,0 +1,11 @@
+# STMicroelectronics BlueNRG-LPS MCU
+
+# Copyright (c) 2024 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+config SOC
+	default "bluenrg_lps"
+	depends on SOC_BLUENRG_LPS
+
+config NUM_IRQS
+	default 32

--- a/soc/st/st_bluenrg/bluenrg_3/Kconfig.soc
+++ b/soc/st/st_bluenrg/bluenrg_3/Kconfig.soc
@@ -1,13 +1,16 @@
-# ST Microelectronics BLUENRG MCU line
+# STMicroelectronics BLUENRG MCU line
 
 # Copyright (c) 2019 Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
 choice
-	prompt "BLUENRG_LP MCU Selection"
+	prompt "BLUENRG_LPx MCU Selection"
 	depends on SOC_SERIES_BLUENRG_3
 
 config SOC_BLUENRG_LP
 	bool "BLUENRG-LP (BlueNRG-355)"
+
+config SOC_BLUENRG_LPS
+	bool "BLUENRG-LPS (BlueNRG-332)"
 
 endchoice

--- a/soc/st/st_bluenrg/bluenrg_3/soc.h
+++ b/soc/st/st_bluenrg/bluenrg_3/soc.h
@@ -5,59 +5,34 @@
 //  * SPDX-License-Identifier: Apache-2.0
 //  */
 
-// /**
-//  * @file SoC configuration macros for the STM32L4 family processors.
-//  *
-//  * Based on reference manual:
-//  *   STM32L4x1, STM32L4x2, STM32L431xx STM32L443xx STM32L433xx, STM32L4x5,
-//  *   STM32l4x6 advanced ARM(r)-based 32-bit MCUs
-//  *
-//  * Chapter 2.2.2: Memory map and register boundary addresses
-//  */
+/**
+ * @file SoC configuration macros for the STM32L4 family processors.
+ *
+ * Based on reference manual:
+ *   STM32L4x1, STM32L4x2, STM32L431xx STM32L443xx STM32L433xx, STM32L4x5,
+ *   STM32l4x6 advanced ARM(r)-based 32-bit MCUs
+ *
+ * Chapter 2.2.2: Memory map and register boundary addresses
+ */
 
 #ifndef _BLUENRG_LP_SOC_H_
 #define _BLUENRG_LP_SOC_H_
 
-
-//#include <sys/util.h>
-
-// #ifndef _ASMLANGUAGE
-
 #include <autoconf.h>
+
+#if defined(CONFIG_SOC_BLUENRG_LP)
 #include <BlueNRG_LP.h>
 
+#elif defined(CONFIG_SOC_BLUENRG_LPS)
+#include <BlueNRG_LPS.h>
+
+#else
+	#error "Board not supported"
+#endif /* defined(CONFIG_SOC_BLUENRG_LP) */
+
 /* Add include for DTS generated information */
-//#include <devicetree.h>
 #include <rf_driver_ll_flash.h>
 #include <rf_driver_ll_rcc.h>
 #include <rf_driver_ll_pwr.h>
 #include <rf_driver_ll_system.h>
-//#include <misc.h>
 #endif /* _BLUENRG_LP_SOC_H_ */
-
-
-/*
- * Copyright (c) 2018 Endre Karlson <endre.karlson@gmail.com>
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-/**
- * @file SoC configuration macros for the STM32L0 family processors.
- *
- * Based on reference manual:
- *   STM32L0X advanced ARM ® -based 32-bit MCUs
- *
- * Chapter 2.2: Memory organization
- */
-
-
-// #ifndef _BLUENRG_LP_SOC_H_
-// #define _BLUENRG_LP_SOC_H_
-
-// #ifndef _ASMLANGUAGE
-
-
-// #endif /* !_ASMLANGUAGE */
-
-// #endif /* _BLUENRG_LP_SOC_H_ */

--- a/soc/st/st_bluenrg/soc.yml
+++ b/soc/st/st_bluenrg/soc.yml
@@ -4,3 +4,4 @@ family:
   - name: bluenrg_3
     socs:
     - name: bluenrg_lp
+    - name: bluenrg_lps

--- a/west.yml
+++ b/west.yml
@@ -236,7 +236,7 @@ manifest:
       groups:
         - hal
     - name: hal_bluenrg
-      revision: 910b320d687d048b41e2d1a27a15603f5931fda6
+      revision: 56a3403dcff1ad429c0117ca5ef0593ce3c4d35c
       path: modules/hal/st_bluenrg
       remote: bluenrg_hal
       groups:


### PR DESCRIPTION
Provide support for STEVAL-IDB012V1 board which is based on BlueNRG-LPS.

Add SOC support for BlueNRG-LPS.

Fix naming convention for GPIO_BLUENRG.

Update hal_bluenrg reference to support BlueNRG-LPS.